### PR TITLE
plugs: Grant personal-files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ plugs:
 apps:
   strictly-maven:
     command: bin/maven.sh
-    plugs: [home, network]
+    plugs: [home, network, personal-files]
 
 parts:
   dump:


### PR DESCRIPTION
Some maven plugins will read hidden configuration files in the user's home directory.

I would like to grant access to this interface, so that the end user can choose to `snap connect` to `personal-files`. I'm new to snap, so not 100% if this change would enable this.

See: https://github.com/jgneff/strictly-maven/discussions/2